### PR TITLE
slang-sys: Rebuild if `SLANG_DIR` env changes

### DIFF
--- a/slang-sys/build.rs
+++ b/slang-sys/build.rs
@@ -4,6 +4,7 @@ use std::env;
 use std::path::{Path, PathBuf};
 
 fn main() {
+	println!("cargo:rerun-if-env-changed=SLANG_DIR");
 	let slang_dir = env::var("SLANG_DIR").map(PathBuf::from).expect(
 		"Environment variable `SLANG_DIR` should be set to the directory of a Slang installation.",
 	);


### PR DESCRIPTION
If you change `SLANG_DIR` in the environment, then this helps to cause a rebuild.

This can be seen via `CARGO_LOG=cargo::core::compiler::fingerprint=info cargo build`.

(Note that doing `SLANG_DIR=whatever cargo build` will trigger a rebuild in a different way. This picks up when you've changed it in the global environment.)