### PR TITLE
fix null pointer CStr construction for anonymous types and vars

### DIFF
--- a/src/reflection/ty.rs
+++ b/src/reflection/ty.rs
@@ -60,9 +60,9 @@ impl Type {
 		rcall!(spReflectionType_GetResourceAccess(self))
 	}
 
-	pub fn name(&self) -> &str {
+	pub fn name(&self) -> Option<&str> {
 		let name = rcall!(spReflectionType_GetName(self));
-		unsafe { std::ffi::CStr::from_ptr(name).to_str().unwrap() }
+		unsafe { (!name.is_null()).then(|| std::ffi::CStr::from_ptr(name).to_str().unwrap()) }
 	}
 
 	// TODO: full_name
@@ -194,7 +194,7 @@ impl TypeLayout {
 		self.ty().resource_access()
 	}
 
-	pub fn name(&self) -> &str {
+	pub fn name(&self) -> Option<&str> {
 		self.ty().name()
 	}
 

--- a/src/reflection/variable.rs
+++ b/src/reflection/variable.rs
@@ -5,9 +5,9 @@ use slang_sys as sys;
 pub struct Variable(sys::SlangReflectionVariable);
 
 impl Variable {
-	pub fn name(&self) -> &str {
+	pub fn name(&self) -> Option<&str> {
 		let name = rcall!(spReflectionVariable_GetName(self));
-		unsafe { std::ffi::CStr::from_ptr(name).to_str().unwrap() }
+		unsafe { (!name.is_null()).then(|| std::ffi::CStr::from_ptr(name).to_str().unwrap()) }
 	}
 
 	pub fn ty(&self) -> &Type {


### PR DESCRIPTION
I ran into some segfault trouble when trying to recursively print out type layouts starting from the implicit global struct. It turned out that anonymous variables and types have their respective GetName methods return a null pointer, which isn't safe for CStr construction. I changed the name methods to account for this, in the same way as semantic_name was already doing it.