### PR TITLE
Multiple entry points for SPIRV target (VulkanUseEntryPointName)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -732,6 +732,7 @@ impl CompilerOptions {
 	option!(DebugInformation, debug_information(level: DebugInfoLevel));
 	option!(LineDirectiveMode, line_directive_mode(mode: LineDirectiveMode));
 	option!(Optimization, optimization(level: OptimizationLevel));
+	option!(VulkanUseEntryPointName, use_vulkan_entry_point_names(enable: bool));
 	option!(Obfuscate, obfuscate(enable: bool));
 	option!(GLSLForceScalarLayout, glsl_force_scalar_layout(enable: bool));
 	option!(EmitSpirvDirectly, emit_spirv_directly(enable: bool));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -732,8 +732,8 @@ impl CompilerOptions {
 	option!(DebugInformation, debug_information(level: DebugInfoLevel));
 	option!(LineDirectiveMode, line_directive_mode(mode: LineDirectiveMode));
 	option!(Optimization, optimization(level: OptimizationLevel));
-	option!(VulkanUseEntryPointName, use_vulkan_entry_point_names(enable: bool));
 	option!(Obfuscate, obfuscate(enable: bool));
+	option!(VulkanUseEntryPointName, vulkan_use_entry_point_name(enable: bool));
 	option!(GLSLForceScalarLayout, glsl_force_scalar_layout(enable: bool));
 	option!(EmitSpirvDirectly, emit_spirv_directly(enable: bool));
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,6 +10,7 @@ fn compile() {
 	// All compiler options are available through this builder.
 	let session_options = slang::CompilerOptions::default()
 		.optimization(slang::OptimizationLevel::High)
+		.use_vulkan_entry_point_names(true)
 		.matrix_layout_row(true);
 
 	let target_desc = slang::TargetDesc::default()

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,7 +10,6 @@ fn compile() {
 	// All compiler options are available through this builder.
 	let session_options = slang::CompilerOptions::default()
 		.optimization(slang::OptimizationLevel::High)
-		.use_vulkan_entry_point_names(true)
 		.matrix_layout_row(true);
 
 	let target_desc = slang::TargetDesc::default()


### PR DESCRIPTION
When targetting SPIRV, slang seems to automatically convert all entry point names to "main" due to compatibility issues with GLSL as far as I understand?

This just add the slang compiler option to toggle that, allowing multiple entry points. I tested it in my own project and it works nicely!

You can discard the change I made to the test file, it was just a small check to make sure that the code compiled with the new option.