### PR TITLE
Fix null pointer deref for absent type, var

### DIFF
--- a/src/reflection/ty.rs
+++ b/src/reflection/ty.rs
@@ -60,9 +60,9 @@ impl Type {
 		rcall!(spReflectionType_GetResourceAccess(self))
 	}
 
-	pub fn name(&self) -> Option<&str> {
+	pub fn name(&self) -> &str {
 		let name = rcall!(spReflectionType_GetName(self));
-		unsafe { (!name.is_null()).then(|| std::ffi::CStr::from_ptr(name).to_str().unwrap()) }
+		unsafe { std::ffi::CStr::from_ptr(name).to_str().unwrap() }
 	}
 
 	// TODO: full_name
@@ -92,8 +92,8 @@ impl Type {
 pub struct TypeLayout(sys::SlangReflectionTypeLayout);
 
 impl TypeLayout {
-	pub fn ty(&self) -> &Type {
-		rcall!(spReflectionTypeLayout_GetType(self) as &Type)
+	pub fn ty(&self) -> Option<&Type> {
+		rcall!(spReflectionTypeLayout_GetType(self) as Option<&Type>)
 	}
 
 	pub fn kind(&self) -> sys::SlangTypeKind {
@@ -131,8 +131,8 @@ impl TypeLayout {
 	// TODO: is_array
 	// TODO: unwrap_array
 
-	pub fn element_count(&self) -> usize {
-		self.ty().element_count()
+	pub fn element_count(&self) -> Option<usize> {
+		Some(self.ty()?.element_count())
 	}
 
 	// TODO: total_array_element_count
@@ -170,32 +170,32 @@ impl TypeLayout {
 			.map(move |i| rcall!(spReflectionTypeLayout_GetCategoryByIndex(self, i)))
 	}
 
-	pub fn row_count(&self) -> u32 {
-		self.ty().row_count()
+	pub fn row_count(&self) -> Option<u32> {
+		Some(self.ty()?.row_count())
 	}
 
-	pub fn column_count(&self) -> u32 {
-		self.ty().column_count()
+	pub fn column_count(&self) -> Option<u32> {
+		Some(self.ty()?.column_count())
 	}
 
-	pub fn scalar_type(&self) -> sys::SlangScalarType {
-		self.ty().scalar_type()
+	pub fn scalar_type(&self) -> Option<sys::SlangScalarType> {
+		Some(self.ty()?.scalar_type())
 	}
 
-	pub fn resource_result_type(&self) -> &Type {
-		self.ty().resource_result_type()
+	pub fn resource_result_type(&self) -> Option<&Type> {
+		Some(self.ty()?.resource_result_type())
 	}
 
-	pub fn resource_shape(&self) -> sys::SlangResourceShape {
-		self.ty().resource_shape()
+	pub fn resource_shape(&self) -> Option<sys::SlangResourceShape> {
+		Some(self.ty()?.resource_shape())
 	}
 
-	pub fn resource_access(&self) -> sys::SlangResourceAccess {
-		self.ty().resource_access()
+	pub fn resource_access(&self) -> Option<sys::SlangResourceAccess> {
+		Some(self.ty()?.resource_access())
 	}
 
 	pub fn name(&self) -> Option<&str> {
-		self.ty().name()
+		Some(self.ty()?.name())
 	}
 
 	pub fn matrix_layout_mode(&self) -> sys::SlangMatrixLayoutMode {

--- a/src/reflection/variable.rs
+++ b/src/reflection/variable.rs
@@ -5,9 +5,9 @@ use slang_sys as sys;
 pub struct Variable(sys::SlangReflectionVariable);
 
 impl Variable {
-	pub fn name(&self) -> Option<&str> {
+	pub fn name(&self) -> &str {
 		let name = rcall!(spReflectionVariable_GetName(self));
-		unsafe { (!name.is_null()).then(|| std::ffi::CStr::from_ptr(name).to_str().unwrap()) }
+		unsafe { std::ffi::CStr::from_ptr(name).to_str().unwrap() }
 	}
 
 	pub fn ty(&self) -> &Type {
@@ -43,8 +43,8 @@ impl Variable {
 pub struct VariableLayout(sys::SlangReflectionVariableLayout);
 
 impl VariableLayout {
-	pub fn variable(&self) -> &Variable {
-		rcall!(spReflectionVariableLayout_GetVariable(self) as &Variable)
+	pub fn variable(&self) -> Option<&Variable> {
+		rcall!(spReflectionVariableLayout_GetVariable(self) as Option<&Variable>)
 	}
 
 	// TODO: get_name
@@ -70,8 +70,8 @@ impl VariableLayout {
 		rcall!(spReflectionVariableLayout_GetOffset(self, category))
 	}
 
-	pub fn ty(&self) -> &Type {
-		self.variable().ty()
+	pub fn ty(&self) -> Option<&Type> {
+		Some(self.variable()?.ty())
 	}
 
 	pub fn binding_index(&self) -> u32 {


### PR DESCRIPTION
Some recent Slang release (not quite sure which) seems to have resulted in a change where some variable layouts no longer have associated variables (and likewise for type layouts/types). Previously these layouts had anonymous variables/types instead, where a name access would result in a null-pointer deref. Now, accessing the variable/type itself results in a null-pointer deref.

This PR re-introduces the assumption that variables and types always have names, and also accommodates variable/type layouts without respective variables/types.