### PR TITLE
Implement clone/copy for ids, send/sync for error, changed library finding behavior

### DIFF
--- a/slang-sys/build.rs
+++ b/slang-sys/build.rs
@@ -1,31 +1,42 @@
 extern crate bindgen;
 
 use std::env;
-use std::path::{Path, PathBuf};
 
 fn main() {
 	println!("cargo:rerun-if-env-changed=SLANG_DIR");
+	println!("cargo:rerun-if-env-changed=SLANG_HEADERS_DIR");
+	println!("cargo:rerun-if-env-changed=SLANG_LIBS_DIR");
 	println!("cargo:rerun-if-env-changed=VULKAN_SDK");
 
-	let mut include_file = PathBuf::from("include");
-	let slang_dir = if let Ok(slang_dir) = env::var("SLANG_DIR").map(PathBuf::from) {
-		include_file = include_file.join("slang.h");
-		slang_dir
-	} else if let Ok(vulkan_sdk_dir) = env::var("VULKAN_SDK").map(PathBuf::from) {
-		include_file = include_file.join("slang/slang.h");
-		vulkan_sdk_dir
+	let headers_dir = if let Ok(dir) = env::var("SLANG_HEADERS_DIR") {
+		dir
+	} else if let Ok(dir) = env::var("SLANG_DIR") {
+		format!("{dir}/include")
+	} else if let Ok(dir) = env::var("VULKAN_SDK") {
+		format!("{dir}/include/slang")
 	} else {
-		panic!("Environment `SLANG_DIR` should be set to the directory of a Slang installation, or `VULKAN_SDK` should be set to the directory of the Vulkan SKD installation.");
+		panic!("The environment variable SLANG_HEADERS_DIR, SLANG_DIR, or VULKAN_SDK must be set");
 	};
+	println!("{headers_dir}");
+	let libs_dir = if let Ok(dir) = env::var("SLANG_LIBS_DIR") {
+		dir
+	} else if let Ok(dir) = env::var("SLANG_DIR") {
+		format!("{dir}/lib")
+	} else if let Ok(dir) = env::var("VULKAN_SDK") {
+		format!("{dir}/lib")
+	} else {
+		panic!("The environment variable SLANG_LIBS_DIR, SLANG_DIR, or VULKAN_SDK must be set");
+	};
+	if !libs_dir.is_empty() {
+		println!("cargo:rustc-link-search=native={libs_dir}");
+	}
 
-	let out_dir = env::var("OUT_DIR")
-		.map(PathBuf::from)
-		.expect("Couldn't determine output directory.");
+	let out_dir = env::var("OUT_DIR").expect("Couldn't determine output directory.");
 
-	link_libraries(&slang_dir);
+	println!("cargo:rustc-link-lib=dylib=slang");
 
 	bindgen::builder()
-		.header(slang_dir.join(include_file).to_str().unwrap())
+		.header(format!("{headers_dir}/slang.h").as_str())
 		.clang_arg("-v")
 		.clang_arg("-xc++")
 		.clang_arg("-std=c++17")
@@ -50,19 +61,8 @@ fn main() {
 		.derive_copy(true)
 		.generate()
 		.expect("Couldn't generate bindings.")
-		.write_to_file(out_dir.join("bindings.rs"))
+		.write_to_file(format!("{out_dir}/bindings.rs").as_str())
 		.expect("Couldn't write bindings.");
-}
-
-fn link_libraries(slang_dir: &Path) {
-	let lib_dir = slang_dir.join("lib");
-
-	if !lib_dir.is_dir() {
-		panic!("Couldn't find the `lib` subdirectory in the Slang installation directory.")
-	}
-
-	println!("cargo:rustc-link-search=native={}", lib_dir.display());
-	println!("cargo:rustc-link-lib=dylib=slang");
 }
 
 #[derive(Debug)]

--- a/slang-sys/build.rs
+++ b/slang-sys/build.rs
@@ -11,9 +11,23 @@ fn main() {
 	let headers_dir = if let Ok(dir) = env::var("SLANG_HEADERS_DIR") {
 		dir
 	} else if let Ok(dir) = env::var("SLANG_DIR") {
-		format!("{dir}/include")
+		#[cfg(target_os = "windows")]
+		{
+			format!("{dir}/Include")
+		}
+		#[cfg(not(target_os = "windows"))]
+		{
+			format!("{dir}/include")
+		}
 	} else if let Ok(dir) = env::var("VULKAN_SDK") {
-		format!("{dir}/include/slang")
+		#[cfg(target_os = "windows")]
+		{
+			format!("{dir}/Include/slang")
+		}
+		#[cfg(not(target_os = "windows"))]
+		{
+			format!("{dir}/include/slang")
+		}
 	} else {
 		panic!("The environment variable SLANG_HEADERS_DIR, SLANG_DIR, or VULKAN_SDK must be set");
 	};
@@ -21,9 +35,23 @@ fn main() {
 	let libs_dir = if let Ok(dir) = env::var("SLANG_LIBS_DIR") {
 		dir
 	} else if let Ok(dir) = env::var("SLANG_DIR") {
-		format!("{dir}/lib")
+		#[cfg(target_os = "windows")]
+		{
+			format!("{dir}/Lib")
+		}
+		#[cfg(not(target_os = "windows"))]
+		{
+			format!("{dir}/lib")
+		}
 	} else if let Ok(dir) = env::var("VULKAN_SDK") {
-		format!("{dir}/lib")
+		#[cfg(target_os = "windows")]
+		{
+			format!("{dir}/Lib")
+		}
+		#[cfg(not(target_os = "windows"))]
+		{
+			format!("{dir}/lib")
+		}
 	} else {
 		panic!("The environment variable SLANG_LIBS_DIR, SLANG_DIR, or VULKAN_SDK must be set");
 	};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod reflection;
 mod tests;
 
 use std::ffi::{CStr, CString};
+use std::fmt::Display;
 use std::marker::PhantomData;
 use std::ptr::{null, null_mut};
 
@@ -38,6 +39,29 @@ const fn uuid(data1: u32, data2: u16, data3: u16, data4: [u8; 8]) -> UUID {
 pub enum Error {
 	Code(sys::SlangResult),
 	Blob(Blob),
+}
+
+impl Display for Error {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::Code(code) => {
+				write!(f, "unspecified error")
+			}
+			Self::Blob(blob) => {
+				if let Ok(a) = blob.as_str() {
+					write!(f, "{}", a)
+				} else {
+					Ok(())
+				}
+			}
+		}
+	}
+}
+
+impl std::error::Error for Error {
+	fn description(&self) -> &str {
+		"slang error"
+	}
 }
 
 impl std::fmt::Debug for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,12 +98,18 @@ pub struct ProfileID(sys::SlangProfileID);
 
 impl ProfileID {
 	pub const UNKNOWN: ProfileID = ProfileID(sys::SlangProfileID_SlangProfileUnknown);
+	pub fn is_unknown(&self) -> bool {
+		self.0 == sys::SlangProfileID_SlangProfileUnknown
+	}
 }
 
 pub struct CapabilityID(sys::SlangCapabilityID);
 
 impl CapabilityID {
 	pub const UNKNOWN: CapabilityID = CapabilityID(sys::SlangCapabilityID_SlangCapabilityUnknown);
+	pub fn is_unknown(&self) -> bool {
+		self.0 == sys::SlangCapabilityID_SlangCapabilityUnknown
+	}
 }
 
 unsafe trait Interface: Sized {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,8 @@ impl std::fmt::Debug for Error {
 	}
 }
 
+unsafe impl Send for Error {}
+
 pub type Result<T> = std::result::Result<T, Error>;
 
 pub(crate) fn succeeded(result: sys::SlangResult) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub enum Error {
 impl Display for Error {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
-			Self::Code(code) => {
+			Self::Code(_) => {
 				write!(f, "unspecified error")
 			}
 			Self::Blob(blob) => {
@@ -74,6 +74,7 @@ impl std::fmt::Debug for Error {
 }
 
 unsafe impl Send for Error {}
+unsafe impl Sync for Error {}
 
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ fn result_from_blob(code: sys::SlangResult, blob: *mut sys::slang_IBlob) -> Resu
 		Ok(())
 	}
 }
-
+#[derive(Clone, Copy)]
 pub struct ProfileID(sys::SlangProfileID);
 
 impl ProfileID {
@@ -103,6 +103,7 @@ impl ProfileID {
 	}
 }
 
+#[derive(Clone, Copy)]
 pub struct CapabilityID(sys::SlangCapabilityID);
 
 impl CapabilityID {


### PR DESCRIPTION
# Overview
Various changes I have made for my own usage that I figured might be useful upstream. Feel free to veto anything.
* IDs now implement clone & copy, as well as `is_unknown` which is useful for catching errors in invalid profile/capability strings
* Implement send/sync for errors so they can be handled easier
* Library finding behavior has been updated. New behavior allows specifying library and header location separately if necessary

I haven’t checked on these changes in a while, and I haven’t cleaned them up. Feel free to ignore this, I may come back and clean it up eventually.

Also note that the PR isn’t updated to the latest head. For example I implemented display(incompletely) for error, which has now been implemented separately upstream.