### PR TITLE
Expose getBuildTagString() on GlobalSession.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,6 +216,11 @@ impl GlobalSession {
 		let name = CString::new(name).unwrap();
 		CapabilityID(vcall!(self, findCapability(name.as_ptr())))
 	}
+
+	pub fn get_build_tag_string(&self) -> &str {
+		let tag = vcall!(self, getBuildTagString());
+		unsafe { CStr::from_ptr(tag).to_str().unwrap() }
+	}
 }
 
 #[repr(transparent)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,7 +217,7 @@ impl GlobalSession {
 		CapabilityID(vcall!(self, findCapability(name.as_ptr())))
 	}
 
-	pub fn get_build_tag_string(&self) -> &str {
+	pub fn build_tag_string(&self) -> &str {
 		let tag = vcall!(self, getBuildTagString());
 		unsafe { CStr::from_ptr(tag).to_str().unwrap() }
 	}


### PR DESCRIPTION
Recently ran into the need to check which version of Slang got dynamically linked (Vulkan SDK vs manually downloaded). This exposes the existing `getBuildTagString()` function on `GlobalSession`.