### PR TITLE
`reflection::Decl` return type safety

### DIFF
--- a/src/reflection/decl.rs
+++ b/src/reflection/decl.rs
@@ -7,11 +7,7 @@ pub struct Decl(sys::SlangReflectionDecl);
 impl Decl {
 	pub fn name(&self) -> Option<&str> {
 		let name = rcall!(spReflectionDecl_getName(self));
-		// UnsupportedForReflection returns a null pointer for the name.
-		if name.is_null() {
-			return None;
-		}
-		Some(unsafe { std::ffi::CStr::from_ptr(name).to_str().unwrap() })
+		(!name.is_null()).then(|| unsafe { std::ffi::CStr::from_ptr(name).to_str().unwrap() })
 	}
 
 	pub fn kind(&self) -> DeclKind {

--- a/src/reflection/decl.rs
+++ b/src/reflection/decl.rs
@@ -5,9 +5,13 @@ use crate::{DeclKind, sys};
 pub struct Decl(sys::SlangReflectionDecl);
 
 impl Decl {
-	pub fn name(&self) -> &str {
+	pub fn name(&self) -> Option<&str> {
 		let name = rcall!(spReflectionDecl_getName(self));
-		unsafe { std::ffi::CStr::from_ptr(name).to_str().unwrap() }
+		// UnsupportedForReflection returns a null pointer for the name.
+		if name.is_null() {
+			return None;
+		}
+		Some(unsafe { std::ffi::CStr::from_ptr(name).to_str().unwrap() })
 	}
 
 	pub fn kind(&self) -> DeclKind {

--- a/src/reflection/decl.rs
+++ b/src/reflection/decl.rs
@@ -34,19 +34,19 @@ impl Decl {
 		rcall!(spReflection_getTypeFromDecl(self) as &Type)
 	}
 
-	pub fn as_variable(&self) -> &Variable {
-		rcall!(spReflectionDecl_castToVariable(self) as &Variable)
+	pub fn as_variable(&self) -> Option<&Variable> {
+		rcall!(spReflectionDecl_castToVariable(self) as Option<&Variable>)
 	}
 
-	pub fn as_function(&self) -> &Function {
-		rcall!(spReflectionDecl_castToFunction(self) as &Function)
+	pub fn as_function(&self) -> Option<&Function> {
+		rcall!(spReflectionDecl_castToFunction(self) as Option<&Function>)
 	}
 
-	pub fn as_generic(&self) -> &Generic {
-		rcall!(spReflectionDecl_castToGeneric(self) as &Generic)
+	pub fn as_generic(&self) -> Option<&Generic> {
+		rcall!(spReflectionDecl_castToGeneric(self) as Option<&Generic>)
 	}
 
-	pub fn parent(&self) -> &Decl {
-		rcall!(spReflectionDecl_getParent(self) as &Decl)
+	pub fn parent(&self) -> Option<&Decl> {
+		rcall!(spReflectionDecl_getParent(self) as Option<&Decl>)
 	}
 }

--- a/src/reflection/variable_layout.rs
+++ b/src/reflection/variable_layout.rs
@@ -55,7 +55,7 @@ impl VariableLayout {
 
 	pub fn semantic_name(&self) -> Option<&str> {
 		let name = rcall!(spReflectionVariableLayout_GetSemanticName(self));
-		unsafe { (!name.is_null()).then(|| std::ffi::CStr::from_ptr(name).to_str().unwrap()) }
+		(!name.is_null()).then(|| unsafe { std::ffi::CStr::from_ptr(name).to_str().unwrap() })
 	}
 
 	pub fn semantic_index(&self) -> usize {


### PR DESCRIPTION
This PR changes the returns of the following methods to an `Option<T>`, in order to prevent null dereference errors
- `Decl::name` - items currently unsupported by the reflection system (such as module imports) return a nullptr for their name
- `Decl::as_variable`
- `Decl::as_function`
- `Decl::as_generic`
- `Decl::parent`