### PR TITLE
Add static linking feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,13 @@ license = "MIT OR Apache-2.0"
 categories = ["compilers", "api-bindings"]
 
 [dependencies]
-shader-slang-sys = { path = "slang-sys", version = "0.1.0" }
+shader-slang-sys = { path = "slang-sys", default-features = false, version = "0.1.0" }
 
 [features]
 serde = ["shader-slang-sys/serde"]
+default = ["dynamic"]
+dynamic = ["shader-slang-sys/dynamic"]
+static = ["shader-slang-sys/static"]
 
 [workspace]
 members = ["slang-sys"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,4 @@ shader-slang-sys = { path = "slang-sys", version = "0.1.0" }
 serde = ["shader-slang-sys/serde"]
 
 [workspace]
-members = [
-	"slang-sys"
-]
+members = ["slang-sys"]

--- a/README.md
+++ b/README.md
@@ -55,9 +55,20 @@ Add `shader-slang` to the `[dependencies]` section of your `Cargo.toml`.
 
 Point this library to a Slang installation. An easy way is by installing the [LunarG Vulkan SDK](https://vulkan.lunarg.com) which comes bundled with the Slang compiler. During installation `VULKAN_SDK` is added to the `PATH` and automatically picked up by this library.
 
-Alternatively, download Slang from their [releases page](https://github.com/shader-slang/slang/releases) and manually set the `SLANG_DIR` environment variable to the path of your Slang directory. Copy `slang.dll` to your executable's directory. To compile to DXIL bytecode, also copy `dxil.dll` and `dxcompiler.dll` from the [Microsoft DirectXShaderCompiler](https://github.com/microsoft/DirectXShaderCompiler/releases) to your executable's directory.
+Alternatively, download Slang from their [releases page](https://github.com/shader-slang/slang/releases) and manually set the `SLANG_DIR` environment variable to the path of your Slang directory.
 
 To specify the `include` and `lib` directories separately, set the `SLANG_INCLUDE_DIR` and `SLANG_LIB_DIR` environment variables.
+
+### Dynamic linking
+
+Using feature `dynamic` will dynamically link slang and its dependencies: Copy `slang.dll` to your executable's directory. To compile to DXIL bytecode, also copy `dxil.dll` and `dxcompiler.dll` from the [Microsoft DirectXShaderCompiler](https://github.com/microsoft/DirectXShaderCompiler/releases) to your executable's directory.
+
+### Static linking
+
+Use the `static` feature to link statically slang and its dependencies. When compiling, you'll need these additional environment variables:
+
+- `SLANG_EXTERNAL_DIR`: typically set to '[<slang_source_directory>](https://github.com/shader-slang/slang)/build/external'
+- `LIBSTDCPP_PATH`: to link with libstdc++.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -65,10 +65,9 @@ Using feature `dynamic` will dynamically link slang and its dependencies: Copy `
 
 ### Static linking
 
-Use the `static` feature to link statically slang and its dependencies. When compiling, you'll need these additional environment variables:
+Use the `static` feature to link statically slang and its dependencies. When compiling, you'll need this additional environment variable:
 
 - `SLANG_EXTERNAL_DIR`: typically set to '[<slang_source_directory>](https://github.com/shader-slang/slang)/build/external'
-- `LIBSTDCPP_PATH`: to link with libstdc++.
 
 ## Credits
 

--- a/slang-sys/Cargo.toml
+++ b/slang-sys/Cargo.toml
@@ -14,4 +14,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 bindgen = "0.72.0"
 
 [features]
+default = ["static"]
+dynamic = []
+static = []
 serde = ["dep:serde"]

--- a/slang-sys/Cargo.toml
+++ b/slang-sys/Cargo.toml
@@ -14,7 +14,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 bindgen = "0.72.0"
 
 [features]
-default = ["static"]
+default = ["dynamic"]
 dynamic = []
 static = []
 serde = ["dep:serde"]

--- a/slang-sys/build.rs
+++ b/slang-sys/build.rs
@@ -81,6 +81,9 @@ fn main() {
 		} else if cfg!(target_os = "linux") {
 			// Linux often uses GCC or Clang with libstdc++ as the default C++ standard library, and libc++ is not commonly installed.
 			println!("cargo:rustc-link-lib=stdc++"); // Links libstdc++ on Linux
+		} else {
+			// Fallback
+			println!("cargo:rustc-link-lib=stdc++");
 		}
 	}
 

--- a/slang-sys/build.rs
+++ b/slang-sys/build.rs
@@ -65,7 +65,23 @@ fn main() {
 		println!("cargo:rustc-link-lib=static=miniz");
 		println!("cargo:rustc-link-lib=static=lz4");
 		// C++ library
-		println!("cargo:rustc-link-lib=c++");
+		// The C++ lib has to be the same as the one used to compile Slang,
+		// otherwise you will get errors about missing symbols.
+		// The following is only a best guess depending on platform's defaults.
+		if cfg!(target_os = "windows") {
+			if cfg!(not(target_env = "msvc")) {
+				// MinGW: Link libstdc++
+				println!("cargo:rustc-link-lib=stdc++");
+			} else {
+				// No linking necessary on Windows, the MSVC runtime is linked by default.
+			}
+		} else if cfg!(target_os = "macos") {
+			// macOS uses Apple’s Clang/LLVM by default, which is tightly integrated with libc++.
+			println!("cargo:rustc-link-lib=c++"); // Links libc++ on macOS
+		} else if cfg!(target_os = "linux") {
+			// Linux often uses GCC or Clang with libstdc++ as the default C++ standard library, and libc++ is not commonly installed.
+			println!("cargo:rustc-link-lib=stdc++"); // Links libstdc++ on Linux
+		}
 	}
 
 	let out_dir = env::var("OUT_DIR").expect("Couldn't determine output directory.");

--- a/slang-sys/build.rs
+++ b/slang-sys/build.rs
@@ -64,8 +64,8 @@ fn main() {
 		// External slang dependencies
 		println!("cargo:rustc-link-lib=static=miniz");
 		println!("cargo:rustc-link-lib=static=lz4");
-		// Standard C++ library
-		println!("cargo:rustc-link-lib=stdc++");
+		// C++ library
+		println!("cargo:rustc-link-lib=c++");
 	}
 
 	let out_dir = env::var("OUT_DIR").expect("Couldn't determine output directory.");

--- a/slang-sys/build.rs
+++ b/slang-sys/build.rs
@@ -2,6 +2,11 @@ extern crate bindgen;
 
 use std::env;
 
+#[cfg(not(any(feature = "static", feature = "dynamic")))]
+compile_error!("You must enable either the 'static' or 'dynamic' feature.");
+#[cfg(all(feature = "static", feature = "dynamic"))]
+compile_error!("Both 'static' and 'dynamic' features cannot be enabled at the same time.");
+
 fn main() {
 	println!("cargo:rerun-if-env-changed=SLANG_DIR");
 	println!("cargo:rerun-if-env-changed=SLANG_INCLUDE_DIR");
@@ -32,7 +37,44 @@ fn main() {
 		println!("cargo:rustc-link-search=native={lib_dir}");
 	}
 
-	println!("cargo:rustc-link-lib=dylib=slang");
+	#[cfg(feature = "dynamic")]
+	{
+		println!("cargo:rustc-link-lib=dylib=slang");
+	}
+	#[cfg(feature = "static")]
+	{
+		use std::path::Path;
+		let Ok(external_lib_dir) = env::var("SLANG_EXTERNAL_DIR") else {
+			panic!(
+				"The environment variable SLANG_EXTERNAL_DIR must be set: typically set to '<slang_source_directory>/build/external'"
+			);
+		};
+		let Ok(libstdcpp_path) = env::var("LIBSTDCPP_PATH") else {
+			panic!(
+				"The environment variable LIBSTDCPP_PATH must be set:
+Example:
+- linux: '/usr/lib/gcc/x86_64-linux-gnu/11/'"
+			);
+		};
+		let miniz_lib_dir = Path::new(&external_lib_dir).join("miniz/Release/");
+		let lz4_lib_dir = Path::new(&external_lib_dir).join("lz4/build/cmake/Release/");
+
+		// Add Slang static library search path
+		println!("cargo:rustc-link-search=native={}", lib_dir);
+		println!("cargo:rustc-link-search=native={}", miniz_lib_dir.display());
+		println!("cargo:rustc-link-search=native={}", lz4_lib_dir.display());
+		println!("cargo:rustc-link-search=native={}", libstdcpp_path);
+
+		// Link the core Slang static libraries
+		println!("cargo:rustc-link-lib=static=slang");
+		println!("cargo:rustc-link-lib=static=compiler-core");
+		println!("cargo:rustc-link-lib=static=core");
+		// External slang dependencies
+		println!("cargo:rustc-link-lib=static=miniz");
+		println!("cargo:rustc-link-lib=static=lz4");
+		// Standard C++ library
+		println!("cargo:rustc-link-lib=static=stdc++");
+	}
 
 	let out_dir = env::var("OUT_DIR").expect("Couldn't determine output directory.");
 

--- a/slang-sys/build.rs
+++ b/slang-sys/build.rs
@@ -49,13 +49,6 @@ fn main() {
 				"The environment variable SLANG_EXTERNAL_DIR must be set: typically set to '<slang_source_directory>/build/external'"
 			);
 		};
-		let Ok(libstdcpp_path) = env::var("LIBSTDCPP_PATH") else {
-			panic!(
-				"The environment variable LIBSTDCPP_PATH must be set:
-Example:
-- linux: '/usr/lib/gcc/x86_64-linux-gnu/11/'"
-			);
-		};
 		let miniz_lib_dir = Path::new(&external_lib_dir).join("miniz/Release/");
 		let lz4_lib_dir = Path::new(&external_lib_dir).join("lz4/build/cmake/Release/");
 
@@ -63,7 +56,6 @@ Example:
 		println!("cargo:rustc-link-search=native={}", lib_dir);
 		println!("cargo:rustc-link-search=native={}", miniz_lib_dir.display());
 		println!("cargo:rustc-link-search=native={}", lz4_lib_dir.display());
-		println!("cargo:rustc-link-search=native={}", libstdcpp_path);
 
 		// Link the core Slang static libraries
 		println!("cargo:rustc-link-lib=static=slang");
@@ -73,7 +65,7 @@ Example:
 		println!("cargo:rustc-link-lib=static=miniz");
 		println!("cargo:rustc-link-lib=static=lz4");
 		// Standard C++ library
-		println!("cargo:rustc-link-lib=static=stdc++");
+		println!("cargo:rustc-link-lib=stdc++");
 	}
 
 	let out_dir = env::var("OUT_DIR").expect("Couldn't determine output directory.");


### PR DESCRIPTION
Hello, linking dynamically requires library users to either:
- Bundle their final binary with dynamic libraries
- Provide a way for users to provide their path, and teach them how to do it.

It also makes it difficult to have a self-contained binary, where you just move it anywhere and it works.

An alternative is to statically link as much as we can. Users still need to provide path to libraries when compiling, but the above requirements can be ignored.

This PR adds a feature gate to statically link slang, this linking requires an additional `SLANG_EXTERNAL_DIR` env variable.

I built my slang library from source, setting `"SLANG_LIB_TYPE": "STATIC"` in the `CMakePresets.json`.