### PR TITLE
Fix incorrect pointer cast for GlobalSession in FFI calls

### DIFF
--- a/src/reflection/function.rs
+++ b/src/reflection/function.rs
@@ -1,5 +1,5 @@
 use super::{Generic, Type, UserAttribute, Variable, rcall};
-use crate::{GlobalSession, Modifier, ModifierID, sys};
+use crate::{GlobalSession, Interface, Modifier, ModifierID, sys};
 
 #[repr(transparent)]
 pub struct Function(sys::SlangReflectionFunction);
@@ -45,7 +45,7 @@ impl Function {
 		let name = std::ffi::CString::new(name).unwrap();
 		rcall!(spReflectionFunction_FindUserAttributeByName(
 			self,
-			global_session as *const _ as *mut _,
+			global_session.as_raw(),
 			name.as_ptr()
 		) as Option<&UserAttribute>)
 	}

--- a/src/reflection/variable.rs
+++ b/src/reflection/variable.rs
@@ -1,5 +1,5 @@
 use super::{Generic, Type, UserAttribute, rcall};
-use crate::{GlobalSession, Modifier, ModifierID, succeeded, sys};
+use crate::{GlobalSession, Interface, Modifier, ModifierID, succeeded, sys};
 
 #[repr(transparent)]
 pub struct Variable(sys::SlangReflectionVariable);
@@ -37,7 +37,7 @@ impl Variable {
 		let name = std::ffi::CString::new(name).unwrap();
 		rcall!(spReflectionVariable_FindUserAttributeByName(
 			self,
-			global_session as *const _ as *mut _,
+			global_session.as_raw(),
 			name.as_ptr()
 		) as Option<&UserAttribute>)
 	}


### PR DESCRIPTION
The `find_user_attribute_by_name` functions in `Function` and `Variable` were incorrectly casting `&GlobalSession` using `as *const _ as *mut _`.

This produced a pointer TO the wrapper struct, but the FFI expects the raw COM pointer VALUE contained inside.

Found this because my application segfaulted when I introduced a call to `find_user_attribute_by_name`. 