### PR TITLE
Use *const c_char instead of *const i8

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ pub mod reflection;
 #[cfg(test)]
 mod tests;
 
-use std::ffi::{CStr, CString};
+use std::ffi::{CStr, CString, c_char};
 use std::marker::PhantomData;
 use std::ptr::{null, null_mut};
 
@@ -670,7 +670,7 @@ impl<'a> SessionDesc<'a> {
 		self
 	}
 
-	pub fn search_paths(mut self, paths: &'a [*const i8]) -> Self {
+	pub fn search_paths(mut self, paths: &'a [*const c_char]) -> Self {
 		self.inner.searchPaths = paths.as_ptr();
 		self.inner.searchPathCount = paths.len() as _;
 		self
@@ -728,7 +728,7 @@ impl CompilerOptions {
 		self
 	}
 
-	fn push_strings(mut self, name: CompilerOptionName, s0: *const i8, s1: *const i8) -> Self {
+	fn push_strings(mut self, name: CompilerOptionName, s0: *const c_char, s1: *const c_char) -> Self {
 		self.options.push(sys::slang_CompilerOptionEntry {
 			name,
 			value: sys::slang_CompilerOptionValue {


### PR DESCRIPTION
Building on `aarch64` linux is broken.

On `aarch64` linux, `.as_ptr()` resolves into `*const *const u8` instead of `*const *const i8`. This can be resolved by using `c_char` which seems to match regardless of platform architecture.

```
error[E0308]: mismatched types
   --> /home/lauda/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/shader-slang-0.1.0/src/lib.rs:654:28
    |
654 |         self.inner.searchPaths = paths.as_ptr();
    |         ----------------------   ^^^^^^^^^^^^^^ expected `*const *const u8`, found `*const *const i8`
    |         |
    |         expected due to the type of this binding
    |
    = note: expected raw pointer `*const *const u8`
               found raw pointer `*const *const i8`
```

Tested on `aarch64` and `x86-64` linux.